### PR TITLE
Fix small maxDataPoints in timeseries dashboards

### DIFF
--- a/grafana/rmf-app/src/dashboards/Common Storage Activity (Timeline).json
+++ b/grafana/rmf-app/src/dashboards/Common Storage Activity (Timeline).json
@@ -127,7 +127,6 @@
         "y": 0
       },
       "id": 2,
-      "maxDataPoints": 60,
       "options": {
         "legend": {
           "calcs": [],

--- a/grafana/rmf-app/src/dashboards/Performance Index (Timeline).json
+++ b/grafana/rmf-app/src/dashboards/Performance Index (Timeline).json
@@ -126,7 +126,6 @@
         "y": 0
       },
       "id": 2,
-      "maxDataPoints": 60,
       "options": {
         "legend": {
           "calcs": [],


### PR DESCRIPTION
Apparently maxDataPoints = 60 were set for some dashboards by mistake.
It breaks graphics for longer timeseries.