### PR TITLE
Rework data source editor to address SSL / auth issues

### DIFF
--- a/grafana/rmf-app/pkg/plugin/types/types.go
+++ b/grafana/rmf-app/pkg/plugin/types/types.go
@@ -25,12 +25,20 @@ import (
 )
 
 type DatasourceEndpointModel struct {
-	Server             string `json:"path"`
-	Port               string `json:"port"`
-	SSL                bool   `json:"ssl"`
-	UserName           string `json:"userName"`
-	Password           string `json:"password"`
-	VerifyInsecureCert bool   `json:"skipVerify"`
+	// Conventional Grafana HTTP config (see the `DataSourceHttpSettings` UI element)
+	// TODO: the type is to get rid of. We need to re-use one HTTP client on DS level.
+	URL           string
+	IntTimeout    int
+	RawTimeout    string `json:"timeout"`
+	TlsSkipVerify bool   `json:"tlsSkipVerify"`
+	// Legacy: custom RMF settings. We should ge rid of it at some point.
+	Server   string `json:"path"`
+	Port     string `json:"port"`
+	SSL      bool   `json:"ssl"`
+	UserName string `json:"userName"`
+	Password string `json:"password"`
+	// NB: the meaning of JSON field is inverted. If set, we do verify certificates.
+	VerifyInsecureCert bool `json:"skipVerify"`
 	DatasourceUid      string
 }
 

--- a/grafana/rmf-app/src/datasources/rmf-datasource/common/types.ts
+++ b/grafana/rmf-app/src/datasources/rmf-datasource/common/types.ts
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright IBM Corp. 2023.
- * (C) Copyright Rocket Software, Inc. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
+ * (C) Copyright Rocket Software, Inc. 2023-2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DataQuery, DataSourceJsonData, NullValueMode, SelectableValue, ThresholdsMode } from '@grafana/data';
+import {
+  DataQuery,
+  DataSourceJsonData,
+  DataSourceSettings,
+  NullValueMode,
+  SelectableValue,
+  ThresholdsMode
+} from '@grafana/data';
 
 export enum visualisationType {
   auto = 'auto',
@@ -105,20 +112,31 @@ export const defaultQuery: Partial<RMFQuery> = {
  * These are options configured for each DataSource instance
  */
 export interface RMFDataSourceJsonData extends DataSourceJsonData {
+  // Conventional Grafana HTTP config (see the `DataSourceHttpSettings` UI element)
+  tlsSkipVerify?: boolean;
+  // We store it as a string because of complications of UI input validation
+  timeout?: string;
+  // Legacy: custom RMF settings. We should ge rid of it at some point.
   path?: string;
   port?: string;
   ssl?: boolean;
-  userName?: string;  
+  userName?: string;
+  // NB: the meaning of that is inverted. If set, we do verify certificates.
   skipVerify?: boolean;
 }
 
 /**
  * Value that is used in the backend, but never sent over HTTP to the frontend
  */
-export interface RMFDatasourceSecureJsonData {
+export interface RMFDataSourceSecureJsonData {
+  // Conventional Grafana HTTP config (see the `DataSourceHttpSettings` UI element)
+  basicAuthPassword?: string
+  // Legacy: custom RMF settings. We should ge rid of it at some point.
   userName?: string;
   password?: string;
 }
+
+export type RMFDataSourceSettings = DataSourceSettings<RMFDataSourceJsonData, RMFDataSourceSecureJsonData>;
 
 export interface DashboardHistoryItem {
   dashboardId?: number;

--- a/grafana/rmf-app/src/datasources/rmf-datasource/config-editor/config-editor.component.tsx
+++ b/grafana/rmf-app/src/datasources/rmf-datasource/config-editor/config-editor.component.tsx
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright IBM Corp. 2023.
- * (C) Copyright Rocket Software, Inc. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
+ * (C) Copyright Rocket Software, Inc. 2023-2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,176 +14,217 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import React, { PureComponent } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { LegacyForms, PanelContainer } from '@grafana/ui';
-import React, { ChangeEvent, PureComponent, SyntheticEvent } from 'react';
-import { RMFDataSourceJsonData as RMFDataSourceOptions, RMFDatasourceSecureJsonData } from '../common/types';
+import { FieldValidationMessage, InlineField, InlineSwitch, LegacyForms } from '@grafana/ui';
+import { RMFDataSourceSettings, RMFDataSourceJsonData, RMFDataSourceSecureJsonData } from '../common/types';
 
 require('./config-editor.component.css');
 
-const { FormField, Switch } = LegacyForms;
+const { FormField } = LegacyForms;
+const FIELD_LABEL_WIDTH = 10;
+const FIELD_INPUT_WIDTH= 20;
+const SWITCH_LABEL_WIDTH = 20;
+const DEFAULT_HTTP_TIMEOUT = "60";
 
-interface Props extends DataSourcePluginOptionsEditorProps<RMFDataSourceOptions, RMFDatasourceSecureJsonData> { }
+type Props = DataSourcePluginOptionsEditorProps<RMFDataSourceJsonData, RMFDataSourceSecureJsonData>;
 
-interface State { }
+interface State {
+  urlError?: string;
+  httpTimeoutError?: string
+  basicAuthUserError?: string
+}
+
 
 export default class ConfigEditor extends PureComponent<Props, State> {
-  constructor(props: DataSourcePluginOptionsEditorProps<RMFDataSourceOptions, RMFDatasourceSecureJsonData>) {
+  constructor(props: Props) {
     super(props);
-    const { options, onOptionsChange } = props;
-    const { jsonData, secureJsonData } = options;
 
-    if (jsonData === undefined || jsonData.path === undefined) {
-      const jsonData = {
-        ...options.jsonData,
+    const {options, onOptionsChange} = props;
+    const {jsonData, secureJsonData} = options;
+    this.state = {}
+
+    if (jsonData?.path !== undefined || jsonData?.port !== undefined) {
+      // Convert from the legacy format if possible
+      options.url = `http${jsonData?.ssl? "s": ""}://${jsonData.path}${jsonData?.port? ":" + jsonData.port: ""}`;
+      let username = (jsonData?.userName || "").trim();
+      if (username) {
+        options.basicAuth = true;
+        options.basicAuthUser = username;
+      }
+      options.jsonData = {
+        timeout: DEFAULT_HTTP_TIMEOUT,
+        tlsSkipVerify: jsonData?.skipVerify || false
       };
-      onOptionsChange({ ...options, jsonData });
+      options.secureJsonData = { basicAuthPassword: secureJsonData?.password || "" }
+    } else {
+      // Initialize jsonData and secureJsonData if needed
+      options.jsonData = {
+        timeout: jsonData?.timeout || DEFAULT_HTTP_TIMEOUT,
+        tlsSkipVerify: jsonData?.tlsSkipVerify || false
+      };
+      options.secureJsonData = { basicAuthPassword: secureJsonData?.basicAuthPassword || "" }
     }
-    if (secureJsonData === undefined) {
-      const secureJsonData = {
-        ...options.secureJsonData,
-      };
-      onOptionsChange({ ...options, secureJsonData });
+    onOptionsChange({...options});
+  }
+
+  urlRegex = /^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/
+
+  validateUrl = (url: string) => {
+    if (this.urlRegex.test(url)) {
+      this.setState({ urlError: undefined });
+    } else {
+      this.setState({ urlError: 'Invalid DDS URL' });
     }
   }
 
-  onPathChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    const jsonData = {
-      ...options.jsonData,
-      path: event.target.value,
-    };
-    onOptionsChange({ ...options, jsonData });
-  };
+  validateHttpTimeout = (value: string) => {
+    let numValue= Number(value)
+    if (numValue > 0 && Number.isInteger(numValue)) {
+      this.setState({ httpTimeoutError: undefined });
+    } else {
+      this.setState({ httpTimeoutError: 'Timeout must be a positive integer' });
+    }
+  }
 
-  onPortChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    const jsonData = {
-      ...options.jsonData,
-      port: event.target.value,
-    };
-    onOptionsChange({ ...options, jsonData });
-  };
+  validateUsername = (value: string) => {
+    if (value?.trim().length > 0) {
+      this.setState({ basicAuthUserError: undefined });
+    } else {
+      this.setState({ basicAuthUserError: 'Username cannot be blank' });
+    }
+  }
 
-  onSSLCheckChange = (event: SyntheticEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    // remove username and password if SSL is unselected
-    const jsonData = {
-      ...options.jsonData,
-      ssl: event.currentTarget.checked,
-      userName: '',
-      skipVerify: event.currentTarget.checked,
-    };
-    const secureJsonData = {
-      ...options.secureJsonData,
-      password: '',
-    };
-    onOptionsChange({...options, jsonData: jsonData, secureJsonData: secureJsonData});
-  };
-
-  onSkipVerifySCheckChange = (event: SyntheticEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    // remove username and password if SSL is unselected
-    const jsonData = {
-      ...options.jsonData,
-      skipVerify: (options.jsonData.ssl && options.jsonData.ssl === true) ? event.currentTarget.checked : false,
-    };
-    onOptionsChange({ ...options, jsonData });
-  };
-
-  onUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    const jsonData = {
-      ...options.jsonData,
-      userName: options.jsonData.ssl ? event.target.value : '',
-    };
-    onOptionsChange({ ...options, jsonData });
-  };
-
-  onPasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-    onOptionsChange({
-      ...options,
-      secureJsonData: {
-        ...options.secureJsonData,
-        password: options.jsonData.ssl ? event.target.value : '',
-      },
-    });
+  updateSettings = (updates: Partial<RMFDataSourceSettings>) => {
+    const { options, onOptionsChange } = this.props;
+    onOptionsChange(
+      { ...options, ...updates,
+        jsonData: {...options.jsonData, ...updates.jsonData},
+        secureJsonData: {...options.secureJsonData, ...updates.secureJsonData},
+      }
+    );
   };
 
   render() {
-    const { options } = this.props;
-    const { jsonData, secureJsonData = {}, secureJsonFields = {} } = options;
+    const {options} = this.props;
+    const {urlError, httpTimeoutError, basicAuthUserError} = this.state;
 
     return (
       <div className="gf-form-group">
-        <label className="width-12 auth-label">Server Information:</label>
-        <div className="gf-form">
-          <FormField
-            label="Server"
-            labelWidth={6}
-            inputWidth={20}
-            onChange={this.onPathChange}
-            value={jsonData.path || ''}
-          />
-        </div>
-        <div className="gf-form">
-          <FormField
-            label="Port"
-            labelWidth={6}
-            inputWidth={20}
-            onChange={this.onPortChange}
-            value={jsonData.port || ''}
-          />
-        </div>
-        <PanelContainer>
-          <label className="width-12 auth-label">Basic Authentication:</label>
+        <h3 className="page-heading">HTTP</h3>
+        <div className="gf-form-group">
           <div className="gf-form">
-            <Switch
-              label="Use SSL"
-              checked={jsonData.ssl || false}
-              tooltip="Enable secure communications"
-              onChange={this.onSSLCheckChange}
+            <FormField
+              label={'DDS URL'}
+              labelWidth={FIELD_LABEL_WIDTH}
+              tooltip="DDS URL needs to be accessible from the grafana backend/server."
+              placeholder="https://dds-server:8803"
+              inputWidth={FIELD_INPUT_WIDTH}
+              value={options.url}
+              onChange={(event) => {
+                this.updateSettings({url: event.currentTarget.value})
+              }}
+              onBlur={(event) => {
+                this.validateUrl(event.currentTarget.value)
+              }}
             />
-          </div>
-          <div className="gf-form">
-            <Switch
-              label="Verify the server's certificate chain/host name"
-              checked={jsonData.skipVerify === undefined ? false : jsonData.skipVerify}
-              tooltip="If disabled the Datasource accepts any certificate presented by the server and any host name in that certificate. This is considered insecure."
-              onChange={this.onSkipVerifySCheckChange}
-              disabled={!jsonData.ssl}
-            />
+            {urlError && (
+              <FieldValidationMessage horizontal={true}>{urlError}</FieldValidationMessage>
+            )}
           </div>
           <div className="gf-form">
             <FormField
-              label="Username"
-              labelWidth={6}
-              inputWidth={20}
-              onChange={this.onUsernameChange}
-              value={jsonData.userName || ''}
-              disabled={!jsonData.ssl}
+              label="Timeout"
+              labelWidth={FIELD_LABEL_WIDTH}
+              tooltip="HTTP request timeout in seconds"
+              placeholder="Timeout in seconds"
+              inputWidth={FIELD_INPUT_WIDTH}
+              value={options.jsonData?.timeout}
+              onChange={(event) => {
+                this.updateSettings({jsonData: {timeout: event.currentTarget.value}})
+              }}
+              onBlur={(event) => {
+                this.validateHttpTimeout(event.currentTarget.value)
+              }}
             />
-            <FormField
-              type="password"
-              label="Password"
-              labelWidth={6}
-              inputWidth={20}
-              onChange={this.onPasswordChange}
-              value={
-                secureJsonData && (secureJsonData as any).password !== undefined ? (secureJsonData as any).password : ''
-              }
-              placeholder={
-                secureJsonFields && (secureJsonFields as any).password !== undefined
-                  ? jsonData.ssl
-                    ? '*********************'
-                    : ''
-                  : ''
-              }
-              disabled={!jsonData.ssl}
-            />
+            {httpTimeoutError && (
+              <FieldValidationMessage horizontal={true}>{httpTimeoutError}</FieldValidationMessage>
+            )}
           </div>
-        </PanelContainer>
+        </div>
+        <h3 className="page-heading">Auth</h3>
+        <div className="gf-form-group">
+          <div className="gf-form-inline">
+            <InlineField label="Basic Auth"
+                         labelWidth={SWITCH_LABEL_WIDTH}
+                         tooltip="Use the basic authentication method">
+              <InlineSwitch
+                value={options.basicAuth}
+                onChange={(event) => {
+                  this.updateSettings(
+                    {
+                      basicAuth: event.currentTarget.checked,
+                      basicAuthUser: "",
+                      secureJsonData: {basicAuthPassword: ""}
+                    })
+                  this.setState({basicAuthUserError: undefined});
+                }}
+              />
+            </InlineField>
+          </div>
+          <div className="gf-form-inline">
+            <InlineField label="Skip TLS Verify"
+                         labelWidth={SWITCH_LABEL_WIDTH}
+                         tooltip="Skip TLS certificate validation">
+              <InlineSwitch
+                value={options.jsonData?.tlsSkipVerify}
+                onChange={(event) => {
+                  this.updateSettings({jsonData: {tlsSkipVerify: event.currentTarget.checked}})
+                }}
+              />
+            </InlineField>
+          </div>
+        </div>
+
+        {(options.basicAuth) && (
+          <>
+            <h6>Basic Auth Details</h6>
+            <div className="gf-form-group">
+              <div className="gf-form">
+                <FormField
+                  label="User"
+                  labelWidth={FIELD_LABEL_WIDTH}
+                  placeholder="User"
+                  inputWidth={FIELD_INPUT_WIDTH}
+                  value={options.basicAuthUser}
+                  onChange={(event) => {
+                    this.updateSettings({basicAuthUser: event.currentTarget.value})
+                  }}
+                  onBlur={(event) => {
+                    this.validateUsername(event.currentTarget.value)
+                  }}
+                />
+                {basicAuthUserError && (
+                  <FieldValidationMessage
+                    horizontal={true}>{basicAuthUserError}</FieldValidationMessage>
+                )}
+              </div>
+              <div className="gf-form">
+                <FormField
+                  label="Password"
+                  labelWidth={FIELD_LABEL_WIDTH}
+                  type="password"
+                  placeholder="Password"
+                  inputWidth={FIELD_INPUT_WIDTH}
+                  value={options.secureJsonData?.basicAuthPassword}
+                  onChange={(event) => {
+                    this.updateSettings({secureJsonData: {basicAuthPassword: event.currentTarget.value}})
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/grafana/rmf-app/src/datasources/rmf-datasource/datasource.ts
+++ b/grafana/rmf-app/src/datasources/rmf-datasource/datasource.ts
@@ -1,6 +1,6 @@
 /**
- * (C) Copyright IBM Corp. 2023.
- * (C) Copyright Rocket Software, Inc. 2023.
+ * (C) Copyright IBM Corp. 2023, 2024.
+ * (C) Copyright Rocket Software, Inc. 2023-2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,23 +18,14 @@ import { DataSourceInstanceSettings, MetricFindValue, ScopedVars } from '@grafan
 import { DataSourceWithBackend, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { getResourceName, queryValidation } from './common/common.helper';
 import { ConfigSettings } from './common/configSettings';
-// import { getPath, getRootXmlPath } from 'common/common.helper';
 import { RMFDataSourceJsonData, RMFQuery, resourceBaseData } from './common/types';
 
 export class DataSource extends DataSourceWithBackend<RMFQuery, RMFDataSourceJsonData> {
-  path = '';
-  url = '';
   dashBoardRefreshed: boolean;
   dashboardName: string;
 
   constructor(instanceSettings: DataSourceInstanceSettings<RMFDataSourceJsonData>) {
     super(instanceSettings);
-    // Used only for WSL localhost
-    // this.path = getPath(getRootXmlPath(instanceSettings));
-
-    // Set for Proxy calls
-    this.url = instanceSettings.url ? instanceSettings.url : '';
-    this.path = this.url + '/proxy';
     this.dashBoardRefreshed = true;
     this.dashboardName = '';
   }

--- a/grafana/rmf-app/yarn.lock
+++ b/grafana/rmf-app/yarn.lock
@@ -8019,6 +8019,7 @@ string-template@~0.2.1:
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8819,6 +8820,7 @@ window-or-global@^1.0.1:
   integrity sha512-tE12J/NenOv4xdVobD+AD3fT06T4KNqnzRhkv5nBIu7K+pvOH2oLCEgYP+i+5mF2jtI6FEADheOdZkA8YWET9w==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- Amend data source editor to make it consistent with standard `DataSourceHttpSettings`.
- Add simple input validation.
- Fix TLS / TLS verify / credentials logic (e.g. it was unable to use https without credentials and vice versa).